### PR TITLE
Handle bash globs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,7 @@ runs:
     - name: prettier
       shell: bash
       run: >-
+        shopt -s globstar nullglob;
         PATH=$(cd $GITHUB_ACTION_PATH; npm bin):$PATH
         prettier
         ${{ inputs.prettier_options }}


### PR DESCRIPTION
The previous system relied on a different shell's magic for handling `*` / `**`

nullglob
- If set, Bash allows filename patterns which match no files to expand to a null string, rather than themselves.

globstar
- If set, the pattern ‘**’ used in a filename expansion context will match all files and zero or more directories and subdirectories. If the pattern is followed by a ‘/’, only directories and subdirectories match.